### PR TITLE
feat(go): run in dir of interest

### DIFF
--- a/.github/actions/sync-workflows/sync.sh
+++ b/.github/actions/sync-workflows/sync.sh
@@ -13,9 +13,10 @@ if [[ -f "${repo_dir}/go.mod" ]]; then
 	types+=("go")
 fi
 
-if [[ -f "${repo_dir}/pyproject.toml" ]] || [[ -f "${repo_dir}/uv.lock" ]] || [[ -f "${repo_dir}/requirements.txt" ]]; then
-	types+=("python")
-fi
+# TODO: add python
+# if [[ -f "${repo_dir}/pyproject.toml" ]] || [[ -f "${repo_dir}/uv.lock" ]] || [[ -f "${repo_dir}/requirements.txt" ]]; then
+# 	types+=("python")
+# fi
 
 # Ensure workflows directory exists
 mkdir -p "${repo_dir}/.github/workflows"

--- a/.github/workflows/go-find-modules.yml
+++ b/.github/workflows/go-find-modules.yml
@@ -1,0 +1,39 @@
+name: find-go-modules
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'directory to use (if specified, auto-detection is skipped)'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      directories:
+        description: 'list of Go module directories in JSON format'
+        value: ${{ jobs.find.outputs.directories }}
+
+jobs:
+  find:
+    runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.find-modules.outputs.directories }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: find-modules
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.working-directory }}" ]]; then
+            # Use specified directory
+            echo "directories=[\"${{ inputs.working-directory }}\"]" >> $GITHUB_OUTPUT
+          else
+            # Auto-detect directories with go.mod files
+            DIRS=$(find . -name "go.mod" -type f -not -path "*/\\.*" -not -path "*/vendor/*" | xargs -I{} dirname {} | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "directories=$DIRS" >> $GITHUB_OUTPUT
+          fi
+
+      - name: debug detected directories
+        run: |
+          echo "Detected Go modules in these directories:"
+          echo '${{ steps.find-modules.outputs.directories }}' | jq -r '.[]'
+          echo "Total modules found: $(echo '${{ steps.find-modules.outputs.directories }}' | jq 'length')"

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -6,35 +6,44 @@ on:
       go-version:
         required: false
         type: string
-        default: 'stable' # rc versions are defined like 1.24.0-rc.3
+        default: 'stable'
       working-directory:
-        description: 'Directory to run golangci-lint in'
+        description: 'directory to run golangci-lint in (if specified, auto-detection is skipped)'
         required: false
         type: string
-        default: '.'
+        default: ''
       config-source:
-        description: 'Source for golangci-lint config (local, golden-latest, golden-revision, central)'
+        description: 'source for golangci-lint config'
         required: false
         type: string
         default: 'golden-latest'
       gist-revision:
-        description: 'Specific Gist revision SHA (used only with golden-revision source)'
+        description: 'specific Gist revision SHA'
         required: false
         type: string
         default: ''
 
 jobs:
+  find-dirs:
+    uses: ./.github/workflows/go-find-modules.yml
+    with:
+      working-directory: ${{ inputs.working-directory }}
+
   golangci:
     name: lint
+    needs: find-dirs
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: ${{ fromJson(needs.find-dirs.outputs.directories) }}
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
-      - name: golangci-lint
-        uses: fredrikaverpil/github/.github/actions/golangci-lint@main
+      - uses: fredrikaverpil/github/.github/actions/golangci-lint@main
         with:
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: ${{ matrix.directory }}
           config-source: ${{ inputs.config-source }}
           gist-revision: ${{ inputs.gist-revision }}

--- a/.github/workflows/go-vuln.yml
+++ b/.github/workflows/go-vuln.yml
@@ -2,40 +2,59 @@ name: vuln
 
 on:
   workflow_call:
+    inputs:
+      go-version:
+        required: false
+        type: string
+        default: 'stable'
+      working-directory:
+        description: 'directory to run vulnerability checks in (if specified, auto-detection is skipped)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
+  find-dirs:
+    uses: ./.github/workflows/go-find-modules.yml
+    with:
+      working-directory: ${{ inputs.working-directory }}
+
   govulncheck:
     runs-on: ubuntu-latest
+    needs: find-dirs
     strategy:
       matrix:
-        go-version: [stable] # rc versions are defined like 1.24.0-rc.3
+        directory: ${{ fromJson(needs.find-dirs.outputs.directories) }}
+      fail-fast: false
     env:
       GOTOOLCHAIN: local
       GOTOOLCHAIN_RESOLVE_PRIVATE: 1
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ inputs.go-version }}
       - id: govulncheck
         uses: golang/govulncheck-action@v1
+        with:
+          working-directory: ${{ matrix.directory }}
 
   gosec:
     runs-on: ubuntu-latest
+    needs: find-dirs
     strategy:
       matrix:
-        go-version: [stable] # rc versions are defined like 1.24.0-rc.3
+        directory: ${{ fromJson(needs.find-dirs.outputs.directories) }}
+      fail-fast: false
     env:
       GOTOOLCHAIN: local
       GOTOOLCHAIN_RESOLVE_PRIVATE: 1
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
-      - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+          go-version: ${{ inputs.go-version }}
+      - uses: securego/gosec@master
+        with:
+          args: "./..."
+          working-directory: ${{ matrix.directory }}


### PR DESCRIPTION
### Why?

- The `go.mod` does not always reside in the repo root.
- There might be several `go.mod` files in the same repo, indicating sub-projects.

### What?

- Run CI tools for each directory where a `go.mod` is found.
